### PR TITLE
ADD option to change file and atempts

### DIFF
--- a/edx_sga/locale/es_419/LC_MESSAGES/django.po
+++ b/edx_sga/locale/es_419/LC_MESSAGES/django.po
@@ -39,6 +39,14 @@ msgid "Display submit button after student uploads a file"
 msgstr "Habilitar botón 'Enviar' después que un estudiante sube un archivo"
 
 #: sga.py:90
+msgid "No. of Attempts"
+msgstr "Nro. de Intentos"
+
+#: sga.py:90
+msgid "Integer representing how many times the problem can be answered"
+msgstr "Entero que representa cuantas veces se puede responder problema"
+
+#: sga.py:90
 msgid "Problem Weight"
 msgstr "Peso del problema"
 
@@ -198,7 +206,7 @@ msgstr "Subido"
 
 #: templates/staff_graded_assignment/show.html:72
 msgid "Submitted"
-msgstr "Enviado"
+msgstr "Finalizado"
 
 #: templates/staff_graded_assignment/show.html:73
 msgid "Grade"
@@ -242,7 +250,7 @@ msgstr "Subir archivo de retroalimentación"
 
 #: templates/staff_graded_assignment/show.html:145
 msgid "Reset Submission"
-msgstr "Permitir nuevo envío"
+msgstr "Reiniciar conteo de envíos"
 
 #: templates/staff_graded_assignment/show.html:143
 msgid "Grade Submissions"
@@ -304,3 +312,7 @@ msgstr "Cancelar"
 #: templates/staff_graded_assignment/show.html:205
 msgid "Remove grade"
 msgstr "Remover calificación"
+
+#: templates/staff_graded_assignment/show.html:205
+msgid "The deadline for this task has passed."
+msgstr "El plazo de entrega para esta tarea a finalizado."

--- a/edx_sga/locale/es_419/LC_MESSAGES/djangojs.po
+++ b/edx_sga/locale/es_419/LC_MESSAGES/djangojs.po
@@ -48,11 +48,11 @@ msgstr "si"
 
 #: static/js/src/edx_sga.js:241
 msgid "Grade must be a number."
-msgstr "Calificación debe ser un numero."
+msgstr "Calificación debe ser un número."
 
 #: static/js/src/edx_sga.js:243
 msgid "Grade must be an integer."
-msgstr "Calificación debe ser un numero entero."
+msgstr "Calificación debe ser un número entero."
 
 #: static/js/src/edx_sga.js:245
 msgid "Grade must be positive."

--- a/edx_sga/static/css/edx_sga.css
+++ b/edx_sga/static/css/edx_sga.css
@@ -96,6 +96,11 @@
     line-height: normal;
 }
 
+.sga-block td .upload.disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
 .sga-block .error {
     color: red;
 }

--- a/edx_sga/templates/staff_graded_assignment/show.html
+++ b/edx_sga/templates/staff_graded_assignment/show.html
@@ -3,10 +3,12 @@
 <div class="sga-block" data-state="{{ student_state }}"
      data-max-size="{{ max_file_size }}" data-support-email="{{ support_email }}"
      data-staff="{{ is_course_staff }}">
+     
   <script type="text/template" id="sga-tmpl">
     <% if (display_name) { %>
       <p>
-        <b><%= display_name %></b>
+        <b><%= display_name %>
+        </b>
       </p>
     <% } %>
     <% if (upload_allowed) { %>
@@ -40,19 +42,30 @@
               <b>{% trans "Annotated file from instructor" %}</b>
               <a href="<%= annotatedUrl %>"><%= annotated.filename %></a><br/>
             <% } %>
-          <% } else if (uploaded && !(upload_allowed && display_submit)) { %>
+          <% } else if (uploaded && !upload_allowed ) { %>
             {% trans "This assignment has not yet been graded." %}
           <% } %>
         </p>
-        <% if (upload_allowed && display_submit) { %>
-          <p><b>
-            {% trans "Para finalizar, presione el botón Enviar. De lo contrario, su trabajo no será calificado." %}
-          </b></p>
-          <p>
-            <button type="button" class="submit btn-brand finalize-upload">
-              <span class="">{% trans "Submit" %}</span>
-            </button>
-          </p>
+        <% if (upload_allowed) { %>
+          <% if (attempts==0) { %>
+            <p><b>
+              {% trans "Presione el botón 'Enviar'. De lo contrario, su trabajo no será calificado." %}
+            </b></p>
+          <% } else { %>
+            <p><b>
+              {% trans "Recuerde presionar el botón 'Enviar' cada vez que desee cambiar de archivo." %}
+            </b></p>
+          <% } %>
+        <% } %>
+        <p>
+          <button type="button" class="submit btn-brand finalize-upload"  <% if (!upload_allowed) { %> disabled<% } %>>
+            <span class="">{% trans "Submit" %}</span>
+          </button>
+        </p>
+        <% if (attempts>0) { %>
+        <span class="submission-feedback">
+          <%= text_attempts %>
+        </span>
         <% } %>
       </div>
     <% } %>
@@ -67,10 +80,15 @@
     <% if (error) { %>
       <p class="error" tabindex="-1" aria-live="polite"><%= error %></p>
     <% } %>
+    <% if (is_past_due) { %>
+      <p><b>
+        {% trans "The deadline for this task has passed." %}
+      </b></p>
+    <% } %>
   </script>
 
   <div id="sga-content">
-  </div>
+  </div>  
 
   {% if is_course_staff %}
   <script type="text/template" id="sga-grading-tmpl">
@@ -81,9 +99,7 @@
         <th class="header">{% trans "Name" %} <i class="icon fa fa-sort"/></th>
         <th class="header">{% trans "Filename" %} <i class="icon fa fa-sort"/></th>
         <th class="header">{% trans "Uploaded" %} <i class="icon fa fa-sort"/></th>
-        <% if (display_submit) { %>
-          <th class="header">{% trans "Submitted" %} <i class="icon fa fa-sort"/></th>
-        <% } %>
+        <th class="header">{% trans "Submitted" %} <i class="icon fa fa-sort"/></th>
         <th class="header">{% trans "Grade" %} <i class="icon fa fa-sort"/></th>
         <th class="header">{% trans "Instructor's comments" %} <i class="icon fa fa-sort"/></th>
         <th class="header">{% trans "Annotated" %} <i class="icon fa fa-sort"/></th>
@@ -92,7 +108,7 @@
       </thead>
       <tbody>
       <% for (var i = 0; i < assignments.length; i++) { %>
-      <%     var assignment = assignments[i]; %>
+      <%  var assignment = assignments[i]; %>
         <tr id="row-<%= assignment.module_id %>"<% if (!assignment.finalized) { %> class="not-finalized"<% } %>>
           <td><%= assignment.username %></td>
           <td><%= assignment.fullname %></td>
@@ -104,15 +120,13 @@
             <% } %>
           </td>
           <td><%= assignment.timestamp %></td>
-          <% if (display_submit) { %>
-            <td>
-              <% if (assignment.finalized) { %>
-                {% trans "Yes" %}
-              <% } else { %>
-                {% trans "No" %}
-              <% } %>
-            </td>
-          <% } %>
+          <td>
+            <% if (assignment.attempts>0) { %>
+              {% trans "Yes" %}
+            <% } else { %>
+              {% trans "No" %}
+            <% } %>
+          </td>
           <td>
             <% if (assignment.score !== null) { %>
               <%= assignment.score %> /
@@ -144,22 +158,20 @@
           <td>
             <div class="upload">
               <label>{% trans "Upload annotated file" %}
-                <input class="fileupload" type="file" name="annotated"/>
+                <input class="fileupload" type="file" name="annotated">
               </label>
             </div>
           </td>
-          <% if (display_submit) { %>
-            <td>
-              <div class="reset-submission">
-                  <button
-                    <% if (!assignment.finalized || assignment.score != null) { %> disabled<% } %> >
-                    {% trans "Reset Submission" %}
-                  </button>
-                  <span class="reset-loading" style="display: none;">{% trans "Loading..." %}</span>
-                  <span class="reset-error" style="display: none;">{% trans "Error" %}</span>
-              </div>
-            </td>
-          <% } %>
+          <td>
+            <div class="reset-submission">
+                <button
+                  <% if (!assignment.no_more_attempts || assignment.score != null) { %> disabled<% } %> >
+                  {% trans "Reset Submission" %}
+                </button>
+                <span class="reset-loading" style="display: none;">{% trans "Loading..." %}</span>
+                <span class="reset-error" style="display: none;">{% trans "Error" %}</span>
+            </div>
+          </td>
         </tr>
       <% } %>
       </tbody>
@@ -173,7 +185,7 @@
 
   <section aria-hidden="true" class="modal staff-modal" id="grade-{{ id }}" style="height: 75%" tabindex="-1">
     <div class="inner-wrapper" style="color: black; overflow: auto;">
-      <header><h2><span class="display_name">{{ display_name }}</span> - {% trans "Staff Graded Assignment" %}</h2></header>
+      <header><h2> <span class="display_name">{{ display_name }}</span> - {% trans "Staff Graded Assignment" %}</h2></header>
       <br/>
       <div>
         <a class="instructor-info-action button btn-download-all" href="#" id="download-init-button">{% trans "Download All Submissions" %}</a>


### PR DESCRIPTION
#### What are the relevant tickets?
On Trello "Desarrollo" ticket is [dev-7](https://trello.com/c/dIubbRk6/7-modificaci%C3%B3n-bloque-sga-para-permitir-reenv%C3%ADos-por-defecto)

#### What's this PR do?

- Add maximum number of attempts as a parameter in the studio view.
- The number of attempts in the studio view is a dropdown from 1 to 10 with 2 being the default value. 
- Make permanent send button and increase the number of attempts when pressing it
- Add the option to change the submitted file.
- Disable the teacher buttons so that the teacher cannot correct before the end date.
- Disable the submit button instead of hiding it.
- Add a message when the deadline has passed.
- When there is no end date add finalized so that when the teacher starts reviewing the student cannot modify the file.
- Modify messages displayed to the user to make the message more understandable.

#### How should this be manually tested?
(Required)

#### Where should the reviewer start?
Creating the 3 cases using different verticals:

- one with end date before the current date.
- one with end date after the current date.
-  one without end date.

 Then seeing how it behaves when delivering the file as well as the teacher buttons.

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
